### PR TITLE
do some code cleanup

### DIFF
--- a/rhasspynlu/arpa_lm.py
+++ b/rhasspynlu/arpa_lm.py
@@ -60,7 +60,7 @@ def fst_to_arpa_tasks(
     """Generate doit compatible tasks for FST to ARPA conversion."""
     # Text -> FST
     fst_text_path = Path(fst_text_path)
-    fst_path = Path(fst_path or (fst_text_path.parent / (fst_text_path.stem + ".fst")))
+    fst_path = Path(fst_path or fst_text_path.with_suffix(".fst"))
 
     yield {
         "name": "compile_fst",

--- a/rhasspynlu/ini_jsgf.py
+++ b/rhasspynlu/ini_jsgf.py
@@ -93,7 +93,7 @@ def parse_ini(
                     sentence = k.strip()
 
                     # Fix \[ escape sequence
-                    sentence = re.sub(r"\\\[", "[", sentence)
+                    sentence = sentence.replace('\\[', '[')
 
                     if sentence_transform:
                         # Do transform
@@ -108,10 +108,10 @@ def parse_ini(
                         sentence = sentence_transform(sentence)
 
                     # Collect key/value pairs as JSGF rules
-                    rule = "<{0}> = ({1});".format(k.strip(), sentence)
+                    rule = f"<{k.strip()}> = ({sentence});"
 
                     # Fix \[ escape sequence
-                    rule = re.sub(r"\\\[", "[", rule)
+                    rule = rule.replace('\\[', '[')
 
                     sentences[sec_name].append(Rule.parse(rule))
     finally:

--- a/rhasspynlu/jsgf.py
+++ b/rhasspynlu/jsgf.py
@@ -192,7 +192,7 @@ def walk_expression(
 
 def split_words(text: str) -> typing.Iterable[Expression]:
     """Split words by whitespace. Detect slot references and substitutions."""
-    for token in re.split(r"\s+", text):
+    for token in text.split():
         if token.startswith("$"):
             if ":" in token:
                 # Slot with substitutions
@@ -273,7 +273,7 @@ def parse_expression(
             found = True
             break
 
-        if (c in [":", "!"]) and (last_c in [")", "]"]):
+        if (c in {":", "!"}) and (last_c in {")", "]"}):
             # Handle sequence substitution/conversion
             assert isinstance(last_taggable, Substitutable)
 
@@ -301,7 +301,7 @@ def parse_expression(
                 conv_text = text[current_index + 1 : next_index].strip()
                 last_taggable.converters = conv_text.split("!")
 
-        elif c in ["<", "(", "[", "{", "|"]:
+        elif c in {"<", "(", "[", "{", "|"}:
             # Begin group/tag/alt/etc.
 
             # Break literal here

--- a/tests/test_fsticuffs.py
+++ b/tests/test_fsticuffs.py
@@ -355,7 +355,7 @@ class TimerTestCase(unittest.TestCase):
 
     def setUp(self):
         # Load timer example
-        self.graph = intents_to_graph(parse_ini(Path("etc") / "timer.ini"))
+        self.graph = intents_to_graph(parse_ini(Path("etc/timer.ini")))
 
     def test_strict_simple(self):
         """Check exact parse."""


### PR DESCRIPTION
- use sets to check if they hold a key since it allows faster lookups than lists
- cleanup usage of pathlib
- use normal string replace and split operations instead of regex operations when possible
- use f-strings when possible (except for logging)